### PR TITLE
Add React Native skeleton with audit logging

### DIFF
--- a/PatientTracker/.gitignore
+++ b/PatientTracker/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+android/
+ios/
+*.log

--- a/PatientTracker/app.json
+++ b/PatientTracker/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "PatientTracker",
+  "displayName": "Patient Tracker"
+}

--- a/PatientTracker/babel.config.js
+++ b/PatientTracker/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+};

--- a/PatientTracker/index.js
+++ b/PatientTracker/index.js
@@ -1,0 +1,5 @@
+import { AppRegistry } from 'react-native';
+import App from './src/App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/PatientTracker/package.json
+++ b/PatientTracker/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "PatientTracker",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "react-native-sqlite-storage": "^6.0.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.21.0",
+    "@babel/runtime": "^7.21.0",
+    "@react-native-community/eslint-config": "^3.2.0",
+    "babel-jest": "^29.4.3",
+    "eslint": "^8.34.0",
+    "jest": "^29.4.3",
+    "metro-react-native-babel-preset": "^0.76.7",
+    "react-test-renderer": "18.2.0"
+  },
+  "jest": {
+    "preset": "react-native"
+  }
+}

--- a/PatientTracker/src/App.js
+++ b/PatientTracker/src/App.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import HospitalListScreen from './screens/HospitalListScreen';
+import AddHospitalScreen from './screens/AddHospitalScreen';
+import PatientListScreen from './screens/PatientListScreen';
+import AddPatientScreen from './screens/AddPatientScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Hospitals" component={HospitalListScreen} />
+        <Stack.Screen name="AddHospital" component={AddHospitalScreen} options={{ title: 'Add Hospital' }} />
+        <Stack.Screen name="Patients" component={PatientListScreen} />
+        <Stack.Screen name="AddPatient" component={AddPatientScreen} options={{ title: 'Add Patient' }} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/PatientTracker/src/screens/AddHospitalScreen.js
+++ b/PatientTracker/src/screens/AddHospitalScreen.js
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, Alert, ScrollView, Text } from 'react-native';
+import { openDatabase } from 'react-native-sqlite-storage';
+
+const db = openDatabase({ name: 'patient.db', location: 'default' });
+
+export default function AddHospitalScreen({ navigation, route }) {
+  const [name, setName] = useState('');
+  const [address, setAddress] = useState('');
+  const [notes, setNotes] = useState('');
+  const [numFloors, setNumFloors] = useState('0');
+  const [floorNotes, setFloorNotes] = useState({});
+
+  const addHospital = () => {
+    if (!name) return Alert.alert('Hospital name required');
+    db.transaction(tx => {
+      tx.executeSql(
+        'INSERT INTO hospitals (name, address, notes) VALUES (?, ?, ?);',
+        [name, address, notes],
+        (_, result) => {
+          const hospitalId = result.insertId;
+          const floorCount = parseInt(numFloors, 10) || 0;
+          for (let i = 1; i <= floorCount; i++) {
+            const note = floorNotes[i] || '';
+            tx.executeSql(
+              'INSERT INTO floors (hospital_id, floor_number, notes) VALUES (?, ?, ?);',
+              [hospitalId, i, note]
+            );
+          }
+        }
+      );
+    }, undefined, () => {
+      route.params?.reload && route.params.reload();
+      navigation.goBack();
+    });
+  };
+
+  return (
+    <ScrollView style={{ flex: 1, padding: 16 }}>
+      <TextInput placeholder="Name" value={name} onChangeText={setName} />
+      <TextInput placeholder="Address" value={address} onChangeText={setAddress} />
+      <TextInput placeholder="Notes" value={notes} onChangeText={setNotes} multiline />
+      <TextInput
+        placeholder="Number of floors"
+        value={numFloors}
+        onChangeText={setNumFloors}
+        keyboardType="numeric"
+      />
+      {Array.from({ length: parseInt(numFloors, 10) || 0 }).map((_, index) => (
+        <TextInput
+          key={index}
+          placeholder={`Floor ${index + 1} notes`}
+          value={floorNotes[index + 1] || ''}
+          onChangeText={text => setFloorNotes({ ...floorNotes, [index + 1]: text })}
+          multiline
+        />
+      ))}
+      <Button title="Save" onPress={addHospital} />
+    </ScrollView>
+  );
+}

--- a/PatientTracker/src/screens/AddPatientScreen.js
+++ b/PatientTracker/src/screens/AddPatientScreen.js
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import { View, TextInput, Button, Alert, Text } from 'react-native';
+import { openDatabase } from 'react-native-sqlite-storage';
+import { Picker } from "@react-native-picker/picker";
+
+const db = openDatabase({ name: 'patient.db', location: 'default' });
+
+export default function AddPatientScreen({ navigation, route }) {
+  const { hospital } = route.params;
+  const [name, setName] = useState('');
+  const [birthdate, setBirthdate] = useState('');
+  const [medicalIssue, setMedicalIssue] = useState('');
+  const [floorId, setFloorId] = useState(null);
+  const [floors, setFloors] = useState([]);
+
+  useEffect(() => {
+    db.transaction(tx => {
+      tx.executeSql(
+        'SELECT id, floor_number FROM floors WHERE hospital_id = ?;',
+        [hospital.id],
+        (_, { rows }) => {
+          const data = [];
+          for (let i = 0; i < rows.length; i++) data.push(rows.item(i));
+          setFloors(data);
+        }
+      );
+    });
+  }, []);
+
+  const addPatient = () => {
+    if (!name) return Alert.alert('Name required');
+    db.transaction(tx => {
+      tx.executeSql(
+        'INSERT INTO patients (name, birthdate, medical_issue, hospital_id, floor_id) VALUES (?, ?, ?, ?, ?);',
+        [name, birthdate, medicalIssue, hospital.id, floorId],
+        () => {
+          route.params?.reload && route.params.reload();
+          navigation.goBack();
+        }
+      );
+    });
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Hospital: {hospital.name}</Text>
+      <TextInput placeholder="Name" value={name} onChangeText={setName} />
+      <TextInput placeholder="Birthdate" value={birthdate} onChangeText={setBirthdate} />
+      <TextInput placeholder="Medical Issue" value={medicalIssue} onChangeText={setMedicalIssue} />
+      <Picker selectedValue={floorId} onValueChange={(value) => setFloorId(value)}>
+        <Picker.Item label="Select Floor" value={null} />
+        {floors.map(f => (
+          <Picker.Item key={f.id} label={`Floor ${f.floor_number}`} value={f.id} />
+        ))}
+      </Picker>
+      <Button title="Save" onPress={addPatient} />
+    </View>
+  );
+}

--- a/PatientTracker/src/screens/HospitalListScreen.js
+++ b/PatientTracker/src/screens/HospitalListScreen.js
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, Button, FlatList, TouchableOpacity } from 'react-native';
+import { openDatabase } from 'react-native-sqlite-storage';
+
+const db = openDatabase({ name: 'patient.db', location: 'default' });
+
+export default function HospitalListScreen({ navigation }) {
+  const [hospitals, setHospitals] = useState([]);
+  const [filter, setFilter] = useState('');
+
+  useEffect(() => {
+    db.transaction(tx => {
+      tx.executeSql(
+        'CREATE TABLE IF NOT EXISTS hospitals (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, address TEXT, notes TEXT);'
+      );
+      tx.executeSql(
+        'CREATE TABLE IF NOT EXISTS floors (id INTEGER PRIMARY KEY AUTOINCREMENT, hospital_id INTEGER, floor_number INTEGER, notes TEXT);'
+      );
+      tx.executeSql(
+        'CREATE TABLE IF NOT EXISTS patients (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, birthdate TEXT, medical_issue TEXT, hospital_id INTEGER, floor_id INTEGER, checked_in INTEGER DEFAULT 1);'
+      );
+    });
+    loadHospitals();
+  }, []);
+
+  const loadHospitals = () => {
+    db.transaction(tx => {
+      tx.executeSql(
+        'SELECT hospitals.id, hospitals.name, hospitals.address, hospitals.notes, COUNT(patients.id) as patientCount FROM hospitals LEFT JOIN patients ON hospitals.id = patients.hospital_id GROUP BY hospitals.id, hospitals.name, hospitals.address, hospitals.notes HAVING hospitals.name LIKE ?;',
+        [`%${filter}%`],
+        (_, { rows }) => {
+          const data = [];
+          for (let i = 0; i < rows.length; i++) {
+            data.push(rows.item(i));
+          }
+          setHospitals(data);
+        }
+      );
+    });
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <TextInput placeholder="Filter hospitals" value={filter} onChangeText={text => setFilter(text)} onSubmitEditing={loadHospitals} />
+      <Button title="Add Hospital" onPress={() => navigation.navigate('AddHospital', { reload: loadHospitals })} />
+      <FlatList
+        data={hospitals}
+        keyExtractor={item => item.id.toString()}
+        renderItem={({ item }) => (
+          <TouchableOpacity onPress={() => navigation.navigate('Patients', { hospital: item })}>
+            <Text style={{ fontSize: 18 }}>{item.name} ({item.patientCount})</Text>
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+  );
+}

--- a/PatientTracker/src/screens/PatientListScreen.js
+++ b/PatientTracker/src/screens/PatientListScreen.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, FlatList, TouchableOpacity } from 'react-native';
+import { openDatabase } from 'react-native-sqlite-storage';
+
+const db = openDatabase({ name: 'patient.db', location: 'default' });
+
+export default function PatientListScreen({ navigation, route }) {
+  const { hospital } = route.params;
+  const [patients, setPatients] = useState([]);
+  const [filter, setFilter] = useState('');
+
+  useEffect(() => {
+    loadPatients();
+  }, [filter]);
+
+  const loadPatients = () => {
+    db.transaction(tx => {
+      tx.executeSql(
+        'SELECT p.id, p.name, p.medical_issue, p.checked_in, f.floor_number FROM patients p LEFT JOIN floors f ON p.floor_id = f.id WHERE p.hospital_id = ? AND p.name LIKE ?;',
+        [hospital.id, `%${filter}%`],
+        (_, { rows }) => {
+          const data = [];
+          for (let i = 0; i < rows.length; i++) {
+            data.push(rows.item(i));
+          }
+          setPatients(data);
+        }
+      );
+    });
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>{hospital.name}</Text>
+      <TextInput placeholder="Filter patients" value={filter} onChangeText={setFilter} />
+      <TouchableOpacity onPress={() => navigation.navigate('AddPatient', { hospital, reload: loadPatients })}>
+        <Text style={{ color: 'blue', marginVertical: 8 }}>Add Patient</Text>
+      </TouchableOpacity>
+      <FlatList
+        data={patients}
+        keyExtractor={item => item.id.toString()}
+        renderItem={({ item }) => (
+          <View style={{ paddingVertical: 4 }}>
+            <Text style={{ color: item.checked_in ? 'black' : 'gray' }}>
+              {item.name} - Floor {item.floor_number || '-'}
+            </Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # hello-world
-Respository Practice
+Repository Practice
+
+## Patient Tracking Database Schema
+See `patient_tracking_schema.sql` for an example SQL schema to manage hospitals, floors, physicians, patients, and attachments.
+
+## React Native Prototype
+
+This repository contains a minimal React Native app in the `PatientTracker` folder. It demonstrates a simple patient tracking system with four screens:
+
+1. **Hospital List** – Filter hospitals by name, view patient counts, and navigate to patient lists.
+2. **Add Hospital** – Create hospitals with notes and a configurable number of floors.
+3. **Patient List** – View and filter patients for a hospital. Patients not checked in appear in gray.
+4. **Add Patient** – Add new patients and assign them to a hospital and floor.
+
+The app stores data in a local SQLite database and includes audit triggers defined in `patient_tracking_schema.sql`.
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) and npm
+- [React Native CLI](https://reactnative.dev/docs/environment-setup)
+- Xcode (for iOS builds on macOS) and Android Studio (for Android)
+
+### Running on macOS (iOS)
+
+```bash
+cd PatientTracker
+npm install
+npx react-native run-ios
+```
+
+### Running on Linux or macOS (Android)
+
+```bash
+cd PatientTracker
+npm install
+npx react-native run-android
+```
+
+### Tests
+
+The project includes a basic Jest configuration. Run tests with:
+
+```bash
+npm test
+```

--- a/patient_tracking_schema.sql
+++ b/patient_tracking_schema.sql
@@ -1,0 +1,123 @@
+-- Sample SQL schema for patient tracking application
+
+-- Table: hospitals
+CREATE TABLE hospitals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    location TEXT
+);
+
+-- Table: floors
+CREATE TABLE floors (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    hospital_id INTEGER NOT NULL,
+    floor_number INTEGER NOT NULL,
+    description TEXT,
+    FOREIGN KEY (hospital_id) REFERENCES hospitals(id)
+);
+
+-- Table: physicians
+CREATE TABLE physicians (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    specialty TEXT
+);
+
+-- Table: patients
+CREATE TABLE patients (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    birthdate DATE,
+    medical_issue TEXT,
+    hospital_id INTEGER,
+    floor_id INTEGER,
+    attending_physician_id INTEGER,
+    notes TEXT,
+    FOREIGN KEY (hospital_id) REFERENCES hospitals(id),
+    FOREIGN KEY (floor_id) REFERENCES floors(id),
+    FOREIGN KEY (attending_physician_id) REFERENCES physicians(id)
+);
+
+-- Table: attachments
+CREATE TABLE attachments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    patient_id INTEGER NOT NULL,
+    file_path TEXT NOT NULL,
+    description TEXT,
+    uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (patient_id) REFERENCES patients(id)
+);
+
+-- Sample indices for performance
+CREATE INDEX idx_patients_hospital ON patients(hospital_id);
+CREATE INDEX idx_patients_floor ON patients(floor_id);
+CREATE INDEX idx_patients_physician ON patients(attending_physician_id);
+
+-- Table: audit_log
+CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    table_name TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    row_id INTEGER,
+    changed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    changed_data TEXT
+);
+
+-- Triggers for audit logging
+CREATE TRIGGER trg_hospitals_ai AFTER INSERT ON hospitals
+BEGIN
+    INSERT INTO audit_log (table_name, operation, row_id, changed_data)
+    VALUES ('hospitals', 'INSERT', NEW.id, json_object('name', NEW.name, 'location', NEW.location));
+END;
+
+CREATE TRIGGER trg_hospitals_au AFTER UPDATE ON hospitals
+BEGIN
+    INSERT INTO audit_log (table_name, operation, row_id, changed_data)
+    VALUES ('hospitals', 'UPDATE', NEW.id, json_object('name', NEW.name, 'location', NEW.location));
+END;
+
+CREATE TRIGGER trg_hospitals_ad AFTER DELETE ON hospitals
+BEGIN
+    INSERT INTO audit_log (table_name, operation, row_id)
+    VALUES ('hospitals', 'DELETE', OLD.id);
+END;
+
+-- Repeat triggers for floors
+CREATE TRIGGER trg_floors_ai AFTER INSERT ON floors
+BEGIN
+    INSERT INTO audit_log (table_name, operation, row_id, changed_data)
+    VALUES ('floors', 'INSERT', NEW.id, json_object('hospital_id', NEW.hospital_id, 'floor_number', NEW.floor_number));
+END;
+
+CREATE TRIGGER trg_floors_au AFTER UPDATE ON floors
+BEGIN
+    INSERT INTO audit_log (table_name, operation, row_id, changed_data)
+    VALUES ('floors', 'UPDATE', NEW.id, json_object('hospital_id', NEW.hospital_id, 'floor_number', NEW.floor_number));
+END;
+
+CREATE TRIGGER trg_floors_ad AFTER DELETE ON floors
+BEGIN
+    INSERT INTO audit_log (table_name, operation, row_id)
+    VALUES ('floors', 'DELETE', OLD.id);
+END;
+
+-- Triggers for patients
+CREATE TRIGGER trg_patients_ai AFTER INSERT ON patients
+BEGIN
+    INSERT INTO audit_log (table_name, operation, row_id, changed_data)
+    VALUES ('patients', 'INSERT', NEW.id, json_object('name', NEW.name, 'hospital_id', NEW.hospital_id));
+END;
+
+CREATE TRIGGER trg_patients_au AFTER UPDATE ON patients
+BEGIN
+    INSERT INTO audit_log (table_name, operation, row_id, changed_data)
+    VALUES ('patients', 'UPDATE', NEW.id, json_object('name', NEW.name, 'hospital_id', NEW.hospital_id));
+END;
+
+CREATE TRIGGER trg_patients_ad AFTER DELETE ON patients
+BEGIN
+    INSERT INTO audit_log (table_name, operation, row_id)
+    VALUES ('patients', 'DELETE', OLD.id);
+END;
+
+


### PR DESCRIPTION
## Summary
- create basic React Native prototype under `PatientTracker`
- implement four screens for hospitals and patients
- add SQLite tables on first run and forms for creating hospitals and patients
- add an audit log table and triggers in the SQL schema
- expand README with build instructions for macOS and Linux

## Testing
- `npm test` *(fails: jest not found)*