### PR TITLE
Add Picker dependency

### DIFF
--- a/PatientTracker/package.json
+++ b/PatientTracker/package.json
@@ -13,7 +13,8 @@
     "@react-navigation/native-stack": "^6.9.12",
     "react": "18.2.0",
     "react-native": "0.72.4",
-    "react-native-sqlite-storage": "^6.0.1"
+    "react-native-sqlite-storage": "^6.0.1",
+    "@react-native-picker/picker": "^2.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",


### PR DESCRIPTION
## Summary
- add `@react-native-picker/picker` to PatientTracker dependencies

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683371c276d88331b7fc735d761c8e69