### PR TITLE
Add placeholder iOS setup

### DIFF
--- a/PatientTracker/.gitignore
+++ b/PatientTracker/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 android/
-ios/
 *.log

--- a/PatientTracker/ios/README.md
+++ b/PatientTracker/ios/README.md
@@ -1,0 +1,14 @@
+# iOS Setup
+
+This directory is a placeholder for the iOS project files needed to run the app on a Mac.
+
+To generate the actual Xcode project, run the following commands on your Mac:
+
+```bash
+cd PatientTracker
+npx react-native init ios --directory ios --skip-install
+cd ios
+pod install
+```
+
+After generating the project, open `PatientTracker.xcworkspace` in Xcode and build the app.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Patient Tracker
 
-A minimal cross-platform (iOS + Android) React-Native prototype for tracking patients by hospital and floor.  
+A minimal cross-platform (iOS + Android) React-Native prototype for tracking patients by hospital and floor.
 All data live in a local SQLite database; audit triggers log every insert, update, and delete.
 
 ---
@@ -26,3 +26,20 @@ Run this command to create a local database and initialize the schema:
 
 ```bash
 sqlite3 patient_tracking.db < patient_tracking_schema.sql
+```
+
+### Running on iOS
+
+The repository does not include the generated iOS project files. To run the React Native app on a Mac:
+
+1. Ensure Xcode and CocoaPods are installed.
+2. From the `PatientTracker` directory, generate the iOS project and install pods:
+   ```bash
+   npx react-native init ios --directory ios --skip-install
+   cd ios
+   pod install
+   ```
+3. Open `PatientTracker.xcworkspace` in Xcode and build the app or run:
+   ```bash
+   npx react-native run-ios
+   ```


### PR DESCRIPTION
## Summary
- add an `ios` directory placeholder with README for generating the iOS project
- explain in the project README how to set up and run the iOS app
- update `.gitignore` so the placeholder directory can be tracked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68674bba0e8c8331868caccbdabe37e5