### PR TITLE
Fix SQLite filename mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ You can load the schema using a database engine of your choice. SQLite is ideal 
 Run this command to create a local database and initialize the schema:
 
 ```bash
-sqlite3 patient_tracking.db < patient_tracking_schema.sql
+sqlite3 patient.db < patient_tracking_schema.sql
+```


### PR DESCRIPTION
## Summary
- fix README to use `patient.db` consistently
- format README snippet correctly

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683371be40c48331b2d9b7e605c52978