### PR TITLE
Add RN CLI devDependency

### DIFF
--- a/PatientTracker/package.json
+++ b/PatientTracker/package.json
@@ -24,7 +24,8 @@
     "eslint": "^8.34.0",
     "jest": "^29.5.0",
     "metro-react-native-babel-preset": "^0.76.7",
-    "react-test-renderer": "18.2.0"
+    "react-test-renderer": "18.2.0",
+    "@react-native-community/cli": "latest"
   },
   "jest": {
     "preset": "react-native",

--- a/patient_tracking_app/package.json
+++ b/patient_tracking_app/package.json
@@ -10,5 +10,8 @@
     "react-native": "0.73.0",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12"
+  },
+  "devDependencies": {
+    "@react-native-community/cli": "latest"
   }
 }


### PR DESCRIPTION
## Summary
- add `@react-native-community/cli` as a devDependency in both apps

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm install --package-lock-only` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6867d08d47cc8331ba228df93a3e9689