### PR TITLE
Add metro.config.js

### DIFF
--- a/PatientTracker/metro.config.js
+++ b/PatientTracker/metro.config.js
@@ -1,0 +1,11 @@
+const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
+
+/**
+ * Metro configuration
+ * https://facebook.github.io/metro/docs/configuration
+ *
+ * @type {import('metro-config').MetroConfig}
+ */
+const config = {};
+
+module.exports = mergeConfig(getDefaultConfig(__dirname), config);

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ The repository does not include the generated iOS project files. To run the Reac
    npx react-native run-ios
    ```
 
+### Running the Metro bundler
+
+The `PatientTracker` directory now includes a minimal `metro.config.js`. After
+installing dependencies, you can start the React Native development server with:
+
+```bash
+cd PatientTracker
+npm install
+npm start
+```
+
 
 ### patient_tracking_app (Expo Demo)
 


### PR DESCRIPTION
## Summary
- fix `No metro config` error by adding `metro.config.js`
- document how to start the Metro server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686829f765788331ab1ce0f4a9b6ce2c