### PR TITLE
Clarify react-native init usage

### DIFF
--- a/PatientTracker/ios/README.md
+++ b/PatientTracker/ios/README.md
@@ -6,8 +6,8 @@ To generate the actual Xcode project, run the following commands on your Mac:
 
 ```bash
 cd PatientTracker
-npx react-native init PatientTracker
-cd ios && pod install
+ npx react-native init PatientTracker --directory .
+ cd ios && pod install
 ```
 
 After generating the project, open `PatientTracker.xcworkspace` in Xcode and build the app.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The repository does not include the generated iOS project files. To run the Reac
 1. Ensure Xcode and CocoaPods are installed.
 2. From the `PatientTracker` directory, initialize the native projects if the `ios` and `android` folders are absent:
    ```bash
-   npx react-native init PatientTracker
+   npx react-native init PatientTracker --directory .
    cd ios && pod install
    ```
    The `init` command creates the native iOS project inside `PatientTracker/ios`.


### PR DESCRIPTION
## Summary
- clarify how to initialize React Native project in-place using `--directory .`

## Testing
- `npx --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684c52aba0833199240f32e008b7fc