### PR TITLE
Align PatientTracker database schema and initialization

### DIFF
--- a/PatientTracker/src/App.js
+++ b/PatientTracker/src/App.js
@@ -1,14 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HospitalListScreen from './screens/HospitalListScreen';
 import AddHospitalScreen from './screens/AddHospitalScreen';
 import PatientListScreen from './screens/PatientListScreen';
 import AddPatientScreen from './screens/AddPatientScreen';
+import { initializeDatabase } from './db';
 
 const Stack = createNativeStackNavigator();
 
 export default function App() {
+  useEffect(() => {
+    initializeDatabase();
+  }, []);
   return (
     <NavigationContainer>
       <Stack.Navigator>

--- a/PatientTracker/src/db.js
+++ b/PatientTracker/src/db.js
@@ -1,0 +1,108 @@
+import { openDatabase } from 'react-native-sqlite-storage';
+
+const db = openDatabase({ name: 'patient_tracking.db', location: 'default' });
+
+export const initializeDatabase = () => {
+  db.transaction(tx => {
+    // Core tables
+    tx.executeSql(`CREATE TABLE IF NOT EXISTS hospitals (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, location TEXT);`);
+    tx.executeSql(`CREATE TABLE IF NOT EXISTS floors (id INTEGER PRIMARY KEY AUTOINCREMENT, hospital_id INTEGER NOT NULL, floor_number INTEGER NOT NULL, description TEXT, FOREIGN KEY (hospital_id) REFERENCES hospitals(id));`);
+    tx.executeSql(`CREATE TABLE IF NOT EXISTS physicians (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, specialty TEXT);`);
+    tx.executeSql(`CREATE TABLE IF NOT EXISTS patients (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, birthdate TEXT, medical_issue TEXT, hospital_id INTEGER, floor_id INTEGER, attending_physician_id INTEGER, notes TEXT, FOREIGN KEY (hospital_id) REFERENCES hospitals(id), FOREIGN KEY (floor_id) REFERENCES floors(id), FOREIGN KEY (attending_physician_id) REFERENCES physicians(id));`);
+    tx.executeSql(`CREATE TABLE IF NOT EXISTS attachments (id INTEGER PRIMARY KEY AUTOINCREMENT, patient_id INTEGER NOT NULL, file_path TEXT NOT NULL, description TEXT, uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY (patient_id) REFERENCES patients(id));`);
+    tx.executeSql(`CREATE TABLE IF NOT EXISTS audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, table_name TEXT NOT NULL, operation TEXT NOT NULL, row_id INTEGER, changed_at DATETIME DEFAULT CURRENT_TIMESTAMP, changed_data TEXT);`);
+
+    // Indices
+    tx.executeSql(`CREATE INDEX IF NOT EXISTS idx_patients_hospital ON patients(hospital_id);`);
+    tx.executeSql(`CREATE INDEX IF NOT EXISTS idx_patients_floor ON patients(floor_id);`);
+    tx.executeSql(`CREATE INDEX IF NOT EXISTS idx_patients_physician ON patients(attending_physician_id);`);
+
+    // Triggers for hospitals
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_hospitals_ai AFTER INSERT ON hospitals
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id, changed_data)
+  VALUES ('hospitals','INSERT',NEW.id,json_object('name',NEW.name,'location',NEW.location));
+END;`);
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_hospitals_au AFTER UPDATE ON hospitals
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id, changed_data)
+  VALUES ('hospitals','UPDATE',NEW.id,json_object('name',NEW.name,'location',NEW.location));
+END;`);
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_hospitals_ad AFTER DELETE ON hospitals
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id)
+  VALUES ('hospitals','DELETE',OLD.id);
+END;`);
+
+    // Triggers for floors
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_floors_ai AFTER INSERT ON floors
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id, changed_data)
+  VALUES ('floors','INSERT',NEW.id,json_object('hospital_id',NEW.hospital_id,'floor_number',NEW.floor_number,'description',NEW.description));
+END;`);
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_floors_au AFTER UPDATE ON floors
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id, changed_data)
+  VALUES ('floors','UPDATE',NEW.id,json_object('hospital_id',NEW.hospital_id,'floor_number',NEW.floor_number,'description',NEW.description));
+END;`);
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_floors_ad AFTER DELETE ON floors
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id)
+  VALUES ('floors','DELETE',OLD.id);
+END;`);
+
+    // Triggers for physicians
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_physicians_ai AFTER INSERT ON physicians
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id, changed_data)
+  VALUES ('physicians','INSERT',NEW.id,json_object('name',NEW.name,'specialty',NEW.specialty));
+END;`);
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_physicians_au AFTER UPDATE ON physicians
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id, changed_data)
+  VALUES ('physicians','UPDATE',NEW.id,json_object('name',NEW.name,'specialty',NEW.specialty));
+END;`);
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_physicians_ad AFTER DELETE ON physicians
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id)
+  VALUES ('physicians','DELETE',OLD.id);
+END;`);
+
+    // Triggers for patients
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_patients_ai AFTER INSERT ON patients
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id, changed_data)
+  VALUES ('patients','INSERT',NEW.id,json_object('name',NEW.name,'hospital_id',NEW.hospital_id,'floor_id',NEW.floor_id,'attending_physician_id',NEW.attending_physician_id));
+END;`);
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_patients_au AFTER UPDATE ON patients
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id, changed_data)
+  VALUES ('patients','UPDATE',NEW.id,json_object('name',NEW.name,'hospital_id',NEW.hospital_id,'floor_id',NEW.floor_id,'attending_physician_id',NEW.attending_physician_id));
+END;`);
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_patients_ad AFTER DELETE ON patients
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id)
+  VALUES ('patients','DELETE',OLD.id);
+END;`);
+
+    // Triggers for attachments
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_attachments_ai AFTER INSERT ON attachments
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id, changed_data)
+  VALUES ('attachments','INSERT',NEW.id,json_object('patient_id',NEW.patient_id,'file_path',NEW.file_path,'description',NEW.description));
+END;`);
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_attachments_au AFTER UPDATE ON attachments
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id, changed_data)
+  VALUES ('attachments','UPDATE',NEW.id,json_object('patient_id',NEW.patient_id,'file_path',NEW.file_path,'description',NEW.description));
+END;`);
+    tx.executeSql(`CREATE TRIGGER IF NOT EXISTS trg_attachments_ad AFTER DELETE ON attachments
+BEGIN
+  INSERT INTO audit_log(table_name, operation, row_id)
+  VALUES ('attachments','DELETE',OLD.id);
+END;`);
+  });
+};
+
+export default db;
+

--- a/PatientTracker/src/screens/AddHospitalScreen.js
+++ b/PatientTracker/src/screens/AddHospitalScreen.js
@@ -1,30 +1,27 @@
 import React, { useState } from 'react';
-import { View, TextInput, Button, Alert, ScrollView, Text } from 'react-native';
-import { openDatabase } from 'react-native-sqlite-storage';
-
-const db = openDatabase({ name: 'patient.db', location: 'default' });
+import { View, TextInput, Button, Alert, ScrollView } from 'react-native';
+import db from '../db';
 
 export default function AddHospitalScreen({ navigation, route }) {
   const [name, setName] = useState('');
-  const [address, setAddress] = useState('');
-  const [notes, setNotes] = useState('');
+  const [location, setLocation] = useState('');
   const [numFloors, setNumFloors] = useState('0');
-  const [floorNotes, setFloorNotes] = useState({});
+  const [floorDescriptions, setFloorDescriptions] = useState({});
 
   const addHospital = () => {
     if (!name) return Alert.alert('Hospital name required');
     db.transaction(tx => {
       tx.executeSql(
-        'INSERT INTO hospitals (name, address, notes) VALUES (?, ?, ?);',
-        [name, address, notes],
+        'INSERT INTO hospitals (name, location) VALUES (?, ?);',
+        [name, location],
         (_, result) => {
           const hospitalId = result.insertId;
           const floorCount = parseInt(numFloors, 10) || 0;
           for (let i = 1; i <= floorCount; i++) {
-            const note = floorNotes[i] || '';
+            const desc = floorDescriptions[i] || '';
             tx.executeSql(
-              'INSERT INTO floors (hospital_id, floor_number, notes) VALUES (?, ?, ?);',
-              [hospitalId, i, note]
+              'INSERT INTO floors (hospital_id, floor_number, description) VALUES (?, ?, ?);',
+              [hospitalId, i, desc]
             );
           }
         }
@@ -38,8 +35,7 @@ export default function AddHospitalScreen({ navigation, route }) {
   return (
     <ScrollView style={{ flex: 1, padding: 16 }}>
       <TextInput placeholder="Name" value={name} onChangeText={setName} />
-      <TextInput placeholder="Address" value={address} onChangeText={setAddress} />
-      <TextInput placeholder="Notes" value={notes} onChangeText={setNotes} multiline />
+      <TextInput placeholder="Location" value={location} onChangeText={setLocation} />
       <TextInput
         placeholder="Number of floors"
         value={numFloors}
@@ -49,9 +45,9 @@ export default function AddHospitalScreen({ navigation, route }) {
       {Array.from({ length: parseInt(numFloors, 10) || 0 }).map((_, index) => (
         <TextInput
           key={index}
-          placeholder={`Floor ${index + 1} notes`}
-          value={floorNotes[index + 1] || ''}
-          onChangeText={text => setFloorNotes({ ...floorNotes, [index + 1]: text })}
+          placeholder={`Floor ${index + 1} description`}
+          value={floorDescriptions[index + 1] || ''}
+          onChangeText={text => setFloorDescriptions({ ...floorDescriptions, [index + 1]: text })}
           multiline
         />
       ))}

--- a/PatientTracker/src/screens/AddPatientScreen.js
+++ b/PatientTracker/src/screens/AddPatientScreen.js
@@ -1,38 +1,37 @@
 import React, { useState, useEffect } from 'react';
 import { View, TextInput, Button, Alert, Text } from 'react-native';
-import { openDatabase } from 'react-native-sqlite-storage';
-import { Picker } from "@react-native-picker/picker";
-
-const db = openDatabase({ name: 'patient.db', location: 'default' });
+import { Picker } from '@react-native-picker/picker';
+import db from '../db';
 
 export default function AddPatientScreen({ navigation, route }) {
   const { hospital } = route.params;
   const [name, setName] = useState('');
   const [birthdate, setBirthdate] = useState('');
   const [medicalIssue, setMedicalIssue] = useState('');
+  const [notes, setNotes] = useState('');
   const [floorId, setFloorId] = useState(null);
   const [floors, setFloors] = useState([]);
 
   useEffect(() => {
-    db.transaction(tx => {
-      tx.executeSql(
-        'SELECT id, floor_number FROM floors WHERE hospital_id = ?;',
-        [hospital.id],
-        (_, { rows }) => {
-          const data = [];
-          for (let i = 0; i < rows.length; i++) data.push(rows.item(i));
-          setFloors(data);
-        }
-      );
-    });
+  db.transaction(tx => {
+    tx.executeSql(
+      'SELECT id, floor_number FROM floors WHERE hospital_id = ?;',
+      [hospital.id],
+      (_, { rows }) => {
+        const data = [];
+        for (let i = 0; i < rows.length; i++) data.push(rows.item(i));
+        setFloors(data);
+      }
+    );
+  });
   }, []);
 
   const addPatient = () => {
     if (!name) return Alert.alert('Name required');
     db.transaction(tx => {
       tx.executeSql(
-        'INSERT INTO patients (name, birthdate, medical_issue, hospital_id, floor_id) VALUES (?, ?, ?, ?, ?);',
-        [name, birthdate, medicalIssue, hospital.id, floorId],
+        'INSERT INTO patients (name, birthdate, medical_issue, hospital_id, floor_id, attending_physician_id, notes) VALUES (?, ?, ?, ?, ?, ?, ?);',
+        [name, birthdate, medicalIssue, hospital.id, floorId, null, notes],
         () => {
           route.params?.reload && route.params.reload();
           navigation.goBack();
@@ -47,7 +46,8 @@ export default function AddPatientScreen({ navigation, route }) {
       <TextInput placeholder="Name" value={name} onChangeText={setName} />
       <TextInput placeholder="Birthdate" value={birthdate} onChangeText={setBirthdate} />
       <TextInput placeholder="Medical Issue" value={medicalIssue} onChangeText={setMedicalIssue} />
-      <Picker selectedValue={floorId} onValueChange={(value) => setFloorId(value)}>
+      <TextInput placeholder="Notes" value={notes} onChangeText={setNotes} />
+      <Picker selectedValue={floorId} onValueChange={value => setFloorId(value)}>
         <Picker.Item label="Select Floor" value={null} />
         {floors.map(f => (
           <Picker.Item key={f.id} label={`Floor ${f.floor_number}`} value={f.id} />

--- a/PatientTracker/src/screens/HospitalListScreen.js
+++ b/PatientTracker/src/screens/HospitalListScreen.js
@@ -1,32 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, Button, FlatList, TouchableOpacity } from 'react-native';
-import { openDatabase } from 'react-native-sqlite-storage';
-
-const db = openDatabase({ name: 'patient.db', location: 'default' });
+import db from '../db';
 
 export default function HospitalListScreen({ navigation }) {
   const [hospitals, setHospitals] = useState([]);
   const [filter, setFilter] = useState('');
 
   useEffect(() => {
-    db.transaction(tx => {
-      tx.executeSql(
-        'CREATE TABLE IF NOT EXISTS hospitals (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, address TEXT, notes TEXT);'
-      );
-      tx.executeSql(
-        'CREATE TABLE IF NOT EXISTS floors (id INTEGER PRIMARY KEY AUTOINCREMENT, hospital_id INTEGER, floor_number INTEGER, notes TEXT);'
-      );
-      tx.executeSql(
-        'CREATE TABLE IF NOT EXISTS patients (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, birthdate TEXT, medical_issue TEXT, hospital_id INTEGER, floor_id INTEGER, checked_in INTEGER DEFAULT 1);'
-      );
-    });
     loadHospitals();
   }, []);
 
   const loadHospitals = () => {
     db.transaction(tx => {
       tx.executeSql(
-        'SELECT hospitals.id, hospitals.name, hospitals.address, hospitals.notes, COUNT(patients.id) as patientCount FROM hospitals LEFT JOIN patients ON hospitals.id = patients.hospital_id GROUP BY hospitals.id, hospitals.name, hospitals.address, hospitals.notes HAVING hospitals.name LIKE ?;',
+        'SELECT hospitals.id, hospitals.name, hospitals.location, COUNT(patients.id) as patientCount FROM hospitals LEFT JOIN patients ON hospitals.id = patients.hospital_id GROUP BY hospitals.id, hospitals.name, hospitals.location HAVING hospitals.name LIKE ?;',
         [`%${filter}%`],
         (_, { rows }) => {
           const data = [];

--- a/PatientTracker/src/screens/PatientListScreen.js
+++ b/PatientTracker/src/screens/PatientListScreen.js
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, FlatList, TouchableOpacity } from 'react-native';
-import { openDatabase } from 'react-native-sqlite-storage';
-
-const db = openDatabase({ name: 'patient.db', location: 'default' });
+import db from '../db';
 
 export default function PatientListScreen({ navigation, route }) {
   const { hospital } = route.params;
@@ -16,8 +14,8 @@ export default function PatientListScreen({ navigation, route }) {
   const loadPatients = () => {
     db.transaction(tx => {
       tx.executeSql(
-        'SELECT p.id, p.name, p.medical_issue, p.checked_in, f.floor_number FROM patients p LEFT JOIN floors f ON p.floor_id = f.id WHERE p.hospital_id = ? AND p.name LIKE ?;',
-        [hospital.id, `%${filter}%`],
+          'SELECT p.id, p.name, p.medical_issue, f.floor_number FROM patients p LEFT JOIN floors f ON p.floor_id = f.id WHERE p.hospital_id = ? AND p.name LIKE ?;',
+          [hospital.id, `%${filter}%`],
         (_, { rows }) => {
           const data = [];
           for (let i = 0; i < rows.length; i++) {
@@ -41,7 +39,7 @@ export default function PatientListScreen({ navigation, route }) {
         keyExtractor={item => item.id.toString()}
         renderItem={({ item }) => (
           <View style={{ paddingVertical: 4 }}>
-            <Text style={{ color: item.checked_in ? 'black' : 'gray' }}>
+            <Text>
               {item.name} - Floor {item.floor_number || '-'}
             </Text>
           </View>


### PR DESCRIPTION
## Summary
- centralize SQLite setup with complete schema, indices, and audit triggers
- align hospital, floor, and patient screens to new schema and shared DB
- add patient notes field and remove unused checked_in column

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68962d1ad80c8331be3dd725b487abab